### PR TITLE
fix softdepend list

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,6 @@ version: '${project.version}'
 main: me.gethertv.getcase.GetCase
 api-version: 1.13
 softdepend:
-  - [Multiverse-Core]
+- Multiverse-Core
 commands:
   getcase:


### PR DESCRIPTION
`softdepend` should be an array of string, it was a list of a list of strings Removing `[` and `]` fixes the issue with loading the plugin before Multiverse-Core. Without this fix, the plugin cannot start properly.